### PR TITLE
Misc updates for the newest VM

### DIFF
--- a/INSTALL_VIRTUAL_MACHINE.md
+++ b/INSTALL_VIRTUAL_MACHINE.md
@@ -3,7 +3,7 @@
 These instructions are to set up a virtual machine as a web server where Evident will be running. To access Evident you need to use the [Google Chrome](https://www.google.com/chrome) web browser in your real machine. Basically, you only need to start the virtual machine when you will use Evident and you access it using Chrome from your machine.
 
 ## Downloads and Installing
-Make sure you have VirtualBox installed in your machine, if not download it and install it from here: [VirtualBox](https://www.virtualbox.org/wiki/Downloads); then download and uncompress this file: [Evident Virtual Machine](ftp://thebeast.colorado.edu/pub/evident-snapshop-VMs/Evident.vdi_100312.tgz) [~ 2GB]
+Make sure you have VirtualBox installed in your machine, if not download it and install it from here: [VirtualBox](https://www.virtualbox.org/wiki/Downloads); then download and uncompress this file: [Evident Virtual Machine](ftp://thebeast.colorado.edu/pub/evident-snapshop-VMs/) [~ 2GB]
 
 To install the virtual hard drive:
 

--- a/data/biom_config
+++ b/data/biom_config
@@ -1,0 +1,1 @@
+python_code_sparse_backend  SparseMat

--- a/evident/__init__.py
+++ b/evident/__init__.py
@@ -12,7 +12,7 @@ __status__ = "Development"
 __all__ = ['subsampling','map_sample_space']
 
 import logging
-from os import chmod
+from os import chmod, environ
 
 # if level is set to DEBUG log messages will be written
 logging.basicConfig(filename='/tmp/e-vident.log', level=logging.DEBUG, \
@@ -23,3 +23,6 @@ try:
     chmod('/tmp/e-vident.log',0777)
 except:
     pass
+
+# performance get's affected by the biom backend used, forced to use SparseMat
+environ['BIOM_CONFIG_FP'] = '/evident/data/biom_config'


### PR DESCRIPTION
BIOM is now forced to use `SparseMat` as a backend using a new configuration file.

To test and make sure that it is working for you, you can call the following lines in `www/handler.psp`:

``` python
import logging
from biom.util import load_biom_config
logging.debug('BIOM %s' % load_biom_config()['python_code_sparse_backend'])
```

---

Once this pull request is merged, I'll update the virtual machine.
